### PR TITLE
auto_ptr のワーニング対応。

### DIFF
--- a/cfg/cfg1.cpp
+++ b/cfg/cfg1.cpp
@@ -61,7 +61,7 @@ namespace
 
     std::string cfg1_out_name;
     get_global( "cfg1_out", cfg1_out_name );
-    std::auto_ptr< typename Factory::cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name + ".c" ) );
+    std::unique_ptr< typename Factory::cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name + ".c" ) );
     cfg1_out->load_cfg( input_file, codeset, factory.get_cfg_info() );
     cfg1_out->generate();
 

--- a/cfg/cfg2.cpp
+++ b/cfg/cfg2.cpp
@@ -67,7 +67,7 @@ namespace
       fatal( _( "no input files" ) );
     }
     std::string cfg1_out_name( get_global_string( "cfg1_out" ) );
-    std::auto_ptr< Cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name ) );
+    std::unique_ptr< Cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name ) );
 
     codeset_t codeset = get_global< codeset_t >( "codeset" );
     cfg1_out->load_cfg( input_file, codeset, factory.get_cfg_info() );
@@ -76,8 +76,8 @@ namespace
       cfg1_out->load_srec();
     }
 
-    std::auto_ptr< macro_processor > mproc;
-    std::auto_ptr< typename Factory::component > component_ptr;
+    std::unique_ptr< macro_processor > mproc;
+    std::unique_ptr< typename Factory::component > component_ptr;
 
     if ( get_global_bool( "with-software-components" ) )
     {

--- a/cfg/cfg3.cpp
+++ b/cfg/cfg3.cpp
@@ -224,13 +224,13 @@ namespace
     }
     std::string cfg1_out_name;
     get_global( "cfg1_out", cfg1_out_name );
-    std::auto_ptr< Cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name ) );
+    std::unique_ptr< Cfg1_out > cfg1_out( factory.create_cfg1_out( cfg1_out_name ) );
 
     codeset_t codeset = get_global< codeset_t >( "codeset" );
     cfg1_out->load_cfg( input_file, codeset, factory.get_cfg_info() );
     cfg1_out->load_srec();
 
-    std::auto_ptr< typename Factory::checker > p_checker( factory.create_checker() );
+    std::tr1::shared_ptr< typename Factory::checker > p_checker( factory.create_checker() );
     std::tr1::shared_ptr< typename Factory::checker > chk( p_checker );
     global( "checker" ) = chk;
     std::string rom_image( get_global_string( "rom-image" ) );
@@ -253,8 +253,8 @@ namespace
       namespace fs = boost::filesystem;
 
       // テンプレート処理
-      std::auto_ptr< macro_processor > mproc;
-      std::auto_ptr< typename Factory::component > component_ptr;
+      std::unique_ptr< macro_processor > mproc;
+      std::unique_ptr< typename Factory::component > component_ptr;
 
       if ( get_global_bool( "with-software-components" ) )
       {

--- a/toppers/itronx/factory.cpp
+++ b/toppers/itronx/factory.cpp
@@ -604,7 +604,7 @@ namespace toppers
     {
     }
 
-    std::auto_ptr< macro_processor > factory::create_macro_processor( cfg1_out const& cfg1out ) const
+    std::unique_ptr< macro_processor > factory::create_macro_processor( cfg1_out const& cfg1out ) const
     {
       cfg1_out::static_api_map api_map( cfg1out.merge() );
       assign_id( api_map );
@@ -786,11 +786,11 @@ namespace toppers
      *  \return     マクロプロセッサへのポインタ
      *  \note   このメンバ関数は従来仕様（ソフトウェア部品非対応版）の温存のためにそのまま残す。
      */
-    std::auto_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const
+    std::unique_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const
     {
       typedef macro_processor::element element;
       typedef macro_processor::var_t var_t;
-      std::auto_ptr< macro_processor > mproc( new macro_processor );
+      std::unique_ptr< macro_processor > mproc( new macro_processor );
       element e;
 
       e.s = " ";    mproc->set_var( "SPC", var_t( 1, e ) );  // $SPC$
@@ -826,11 +826,11 @@ namespace toppers
      *  \param[in]  api_array .cfg ファイルに記述された静的API情報
      *  \return     マクロプロセッサへのポインタ
      */
-    std::auto_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, std::vector< static_api > const& api_array ) const
+    std::unique_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, std::vector< static_api > const& api_array ) const
     {
       typedef macro_processor::element element;
       typedef macro_processor::var_t var_t;
-      std::auto_ptr< macro_processor > mproc( new macro_processor );
+      std::unique_ptr< macro_processor > mproc( new macro_processor );
       element e;
 
       e.s = " ";    mproc->set_var( "SPC", var_t( 1, e ) );  // $SPC$
@@ -859,14 +859,14 @@ namespace toppers
       return mproc;
     }
 
-    std::auto_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
+    std::unique_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
     {
-      return std::auto_ptr< itronx::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
+      return std::unique_ptr< itronx::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
     }
 
-    std::auto_ptr< checker > factory::do_create_checker() const
+    std::unique_ptr< checker > factory::do_create_checker() const
     {
-      return std::auto_ptr< itronx::checker >( new checker );
+      return std::unique_ptr< itronx::checker >( new checker );
     }
 
   }

--- a/toppers/itronx/factory.hpp
+++ b/toppers/itronx/factory.hpp
@@ -78,22 +78,22 @@ namespace toppers
       virtual ~factory();
       std::map< std::string, static_api::info > const* get_static_api_info_map() const;
       cfg1_out::cfg1_def_table const* get_cfg1_def_table() const;
-      std::auto_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
+      std::unique_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
       {
         return do_create_cfg1_out( filename );
       }
-      std::auto_ptr< checker > create_checker() const
+      std::unique_ptr< checker > create_checker() const
       {
         return do_create_checker();
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const;
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const;
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const
       {
         return do_create_macro_processor( cfg1out, api_map );
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::auto_ptr< component >& component_ptr ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::unique_ptr< component >& component_ptr ) const
       {
-        std::auto_ptr< macro_processor > mproc( do_create_macro_processor( cfg1out, cfg1out.get_static_api_array() ) );
+        std::unique_ptr< macro_processor > mproc( do_create_macro_processor( cfg1out, cfg1out.get_static_api_array() ) );
         component_ptr.reset( new component( mproc.get() ) );
         return mproc;
       }
@@ -105,11 +105,11 @@ namespace toppers
       }
     protected:
       virtual void do_swap( factory& other );
-      virtual std::auto_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const;
-      virtual std::auto_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, std::vector< static_api > const& api_array ) const;
+      virtual std::unique_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::static_api_map const& api_map ) const;
+      virtual std::unique_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, std::vector< static_api > const& api_array ) const;
     private:
-      virtual std::auto_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
-      virtual std::auto_ptr< checker > do_create_checker() const;
+      virtual std::unique_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
+      virtual std::unique_ptr< checker > do_create_checker() const;
 
       std::string kernel_;
     };

--- a/toppers/oil/factory.cpp
+++ b/toppers/oil/factory.cpp
@@ -583,11 +583,11 @@ namespace toppers
      *  \param[in]  api_map .cfg ファイルに記述された静的API情報
      *  \return     マクロプロセッサへのポインタ
      */
-    std::auto_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const
+    std::unique_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const
     {
       typedef macro_processor::element element;
       typedef macro_processor::var_t var_t;
-      std::auto_ptr< macro_processor > mproc( new macro_processor );
+      std::unique_ptr< macro_processor > mproc( new macro_processor );
       element e;
 
       e.s = " ";    mproc->set_var( "SPC", var_t( 1, e ) );  // $SPC$
@@ -619,11 +619,11 @@ namespace toppers
      *  \param[in]  api_array .cfg ファイルに記述された静的API情報
      *  \return     マクロプロセッサへのポインタ
      */
-    std::auto_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, std::vector< object_definition* > const& obj_array ) const
+    std::unique_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, std::vector< object_definition* > const& obj_array ) const
     {
       typedef macro_processor::element element;
       typedef macro_processor::var_t var_t;
-      std::auto_ptr< macro_processor > mproc( new macro_processor );
+      std::unique_ptr< macro_processor > mproc( new macro_processor );
       element e;
 
       e.s = " ";    mproc->set_var( "SPC", var_t( 1, e ) );  // $SPC$
@@ -649,13 +649,13 @@ namespace toppers
       return mproc;
     }
 
-    std::auto_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
+    std::unique_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
     {
-      return std::auto_ptr< oil::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
+      return std::unique_ptr< oil::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
     }
-    std::auto_ptr< checker > factory::do_create_checker() const
+    std::unique_ptr< checker > factory::do_create_checker() const
     {
-      return std::auto_ptr< oil::checker >( new checker );
+      return std::unique_ptr< oil::checker >( new checker );
     }
 
   }

--- a/toppers/oil/factory.hpp
+++ b/toppers/oil/factory.hpp
@@ -75,26 +75,26 @@ namespace toppers
       virtual ~factory();
       std::vector<std::string> const* get_object_definition_info() const;
       cfg1_out::cfg1_def_table const* get_cfg1_def_table() const;
-      std::auto_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
+      std::unique_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
       {
         return do_create_cfg1_out( filename );
       }
-      std::auto_ptr< checker > create_checker() const
+      std::unique_ptr< checker > create_checker() const
       {
         return do_create_checker();
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const
       {
         return do_create_macro_processor( cfg1out, cfg1out.merge() );
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const
       {
         return do_create_macro_processor( cfg1out, obj_def_map );
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::auto_ptr< component >& cmponent_ptr ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::unique_ptr< component >& cmponent_ptr ) const
       {
         error( _( "with-software-components is not supported." ) );
-        return std::auto_ptr< macro_processor >();
+        return std::unique_ptr< macro_processor >();
       }
       void swap( factory& other ) { do_swap( other ); }
 
@@ -104,11 +104,11 @@ namespace toppers
       }
     protected:
       virtual void do_swap( factory& other );
-      virtual std::auto_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const;
-      virtual std::auto_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, std::vector< object_definition* > const& obj_array ) const;
+      virtual std::unique_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::cfg_obj_map const& obj_def_map ) const;
+      virtual std::unique_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, std::vector< object_definition* > const& obj_array ) const;
     private:
-      virtual std::auto_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
-      virtual std::auto_ptr< checker > do_create_checker() const;
+      virtual std::unique_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
+      virtual std::unique_ptr< checker > do_create_checker() const;
 
       std::string kernel_;
     };

--- a/toppers/xml/factory.cpp
+++ b/toppers/xml/factory.cpp
@@ -1049,11 +1049,11 @@ namespace toppers
      *  \return     マクロプロセッサへのポインタ
      *  \note   このメンバ関数は従来仕様（ソフトウェア部品非対応版）の温存のためにそのまま残す。
      */
-    std::auto_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const
+    std::unique_ptr< macro_processor > factory::do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const
     {
       typedef macro_processor::element element;
       typedef macro_processor::var_t var_t;
-      std::auto_ptr< macro_processor > mproc( new macro_processor );
+      std::unique_ptr< macro_processor > mproc( new macro_processor );
       element e;
 
       e.s = " ";    mproc->set_var( "SPC", var_t( 1, e ) );  // $SPC$
@@ -1087,13 +1087,13 @@ namespace toppers
       return mproc;
     }
 
-    std::auto_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
+    std::unique_ptr< cfg1_out > factory::do_create_cfg1_out( std::string const& filename ) const
     {
-      return std::auto_ptr< xml::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
+      return std::unique_ptr< xml::cfg1_out >( new cfg1_out( filename, get_cfg1_def_table() ) );
     }
-    std::auto_ptr< checker > factory::do_create_checker() const
+    std::unique_ptr< checker > factory::do_create_checker() const
     {
-      return std::auto_ptr< xml::checker >( new checker );
+      return std::unique_ptr< xml::checker >( new checker );
     }
 
   }

--- a/toppers/xml/factory.hpp
+++ b/toppers/xml/factory.hpp
@@ -96,27 +96,27 @@ namespace toppers
       virtual ~factory();
       std::map< std::string, toppers::xml::info > const* get_container_info_map() const;
       cfg1_out::cfg1_def_table const* get_cfg1_def_table() const;
-      std::auto_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
+      std::unique_ptr< cfg1_out > create_cfg1_out( std::string const& filename ) const
       {
         return do_create_cfg1_out( filename );
       }
-      std::auto_ptr< checker > create_checker() const
+      std::unique_ptr< checker > create_checker() const
       {
         return do_create_checker();
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out ) const
       {
         cfg1_out::xml_obj_map xml_map( cfg1out.merge( *get_container_info_map() ) );
         return do_create_macro_processor( cfg1out, xml_map );
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const
       {
         return do_create_macro_processor( cfg1out, xml_map );
       }
-      std::auto_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::auto_ptr< component >& cmponent_ptr ) const
+      std::unique_ptr< macro_processor > create_macro_processor( cfg1_out const& cfg1out, std::unique_ptr< component >& cmponent_ptr ) const
       {
         error( _( "with-software-components is not supported." ) );
-        return std::auto_ptr< macro_processor >();
+        return std::unique_ptr< macro_processor >();
       }
       void swap( factory& other ) { do_swap( other ); }
 
@@ -134,10 +134,10 @@ namespace toppers
  
     protected:
       virtual void do_swap( factory& other );
-      virtual std::auto_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const;
+      virtual std::unique_ptr< macro_processor > do_create_macro_processor( cfg1_out const& cfg1out, cfg1_out::xml_obj_map const& xml_map ) const;
     private:
-      virtual std::auto_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
-      virtual std::auto_ptr< checker > do_create_checker() const;
+      virtual std::unique_ptr< cfg1_out > do_create_cfg1_out( std::string const& filename ) const;
+      virtual std::unique_ptr< checker > do_create_checker() const;
 
       std::string kernel_;
     };


### PR DESCRIPTION
#2 の対応です。

- 基本的に `unique_ptr` に変更
- [`cfg/cfg3.cpp` の L233](https://github.com/mikoto2000/cfg-1/commit/f6e6357344a6882f2e25c9daaf3988620b377ee2#diff-d34070ef42249a35285b528a6c6c0624R233) だけは、 `chk` 関数が `shared_ptr` を要求するので `shared_ptr` へ変更