### PR TITLE
sscanf のワーニング対応。

### DIFF
--- a/toppers/oil/factory.cpp
+++ b/toppers/oil/factory.cpp
@@ -161,14 +161,14 @@ namespace toppers
               {
                                 // modified by takuya 110823
                 //sscanf_s(value_str.c_str() , "0x%I64x" , &temp);
-                sscanf(value_str.c_str() , "0x%llx" , &temp);
+                sscanf(value_str.c_str() , "0x%lx" , &temp);
                 e.i = temp;
               }
               else if(value_str.find("0X") == 0)
               {
                                 // modified by takuya 110823
                 //sscanf_s(value_str.c_str() , "0X%I64x" , &temp);
-                sscanf(value_str.c_str() , "0X%llx" , &temp);
+                sscanf(value_str.c_str() , "0X%lx" , &temp);
                 e.i = temp;
               }
               else
@@ -195,14 +195,14 @@ namespace toppers
               {
                                 // modified by takuya 110823
                 //sscanf_s(value_str.c_str() , "0x%I64x" , &temp);
-                sscanf(value_str.c_str() , "0x%llx" , &temp);
+                sscanf(value_str.c_str() , "0x%lx" , &temp);
                 e.i = temp;
               }
               else if(value_str.find("0X") == 0)
               {
                                 // modified by takuya 110823
                 //sscanf_s(value_str.c_str() , "0X%I64x" , &temp);
-                sscanf(value_str.c_str() , "0X%llx" , &temp);
+                sscanf(value_str.c_str() , "0X%lx" , &temp);
                 e.i = temp;
               }
               else

--- a/toppers/oil/oil_object.cpp
+++ b/toppers/oil/oil_object.cpp
@@ -316,13 +316,13 @@ namespace toppers
 				{
                     // modified by takuya 110823
 					//(void)sscanf_s(obj->get_value().c_str() , "0x%I64x" , &value);
-					(void)sscanf(obj->get_value().c_str() , "0x%llx" , &value);
+					(void)sscanf(obj->get_value().c_str() , "0x%lx" , &value);
 				}
 				else if(obj->get_value().find("0X") != string::npos)
 				{
                     // modified by takuya 110823
 					//(void)sscanf_s(obj->get_value().c_str() , "0X%I64x" , &value);
-					(void)sscanf(obj->get_value().c_str() , "0X%llx" , &value);
+					(void)sscanf(obj->get_value().c_str() , "0X%lx" , &value);
 				}
 				else
 				{
@@ -395,13 +395,13 @@ namespace toppers
 				{
                     // modified by takuya 110823
 					//(void)sscanf_s(obj->get_value().c_str() , "0x%I64x" , &value);
-					(void)sscanf(obj->get_value().c_str() , "0x%llx" , &value);
+					(void)sscanf(obj->get_value().c_str() , "0x%lx" , &value);
 				}
 				else if(obj->get_value().find("0X") != string::npos)
 				{
                     // modified by takuya 110823
 					//(void)sscanf_s(obj->get_value().c_str() , "0X%I64x" , &value);
-					(void)sscanf(obj->get_value().c_str() , "0X%llx" , &value);
+					(void)sscanf(obj->get_value().c_str() , "0X%lx" , &value);
 				}
 				else
 				{


### PR DESCRIPTION
#2 でとり切れない `sscanf` のワーニング対応です。

■ 原因

`%llx` は `long long unsigned int` のための変換指定子だが、 Linux 64bit の `uint64_t` の実体は `long unsigned int` であるため、ワーニングが出ている。

■ 対応
`long unsigned int` 用の変換指定子である `%lx` に修正。