### PR TITLE
最適化を無効にしたスタティックリンクバイナリ作成を行う

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "depend_libs/xerces-c"]
+	path = depend_libs/xerces-c
+	url = https://github.com/apache/xerces-c.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: cpp
 
+env:
+  global:
+    # 本当は CXXFLAGS らしいのだけど、こっちじゃないと認識しないので...
+    CPPFLAGS='-std=c++11'
 matrix:
     include:
         - os: osx
@@ -16,14 +20,14 @@ addons:
     - perl
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libboost-all-dev; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libxerces-c-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y cmake; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew update          ; fi
 #    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install boost; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install xerces-c; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install icu4c; fi
 
 script: 
-    ./configure --with-xml && make
+    ./build.sh
 after_success:
     - cd cfg ; tar cvzf "cfg-${TRAVIS_BRANCH}-${TARGET}.tar.gz" cfg ; cd ../
     - mkdir -p $TRAVIS_BUILD_DIR/dist ; cp cfg/"cfg-${TRAVIS_BRANCH}-${TARGET}.tar.gz" $TRAVIS_BUILD_DIR/dist/ ; cd $TRAVIS_BUILD_DIR/dist

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 # 非力なマシンなどでコンパイルに非常に長い時間がかかる、もしくはコンパイル時に
 # ハングアップする場合には、-O0に変更してみてください。
-OPTIMIZE = -O2
+OPTIMIZE = -O0
 
 MODULES = toppers/itronx \
 	toppers/oil

--- a/build.sh
+++ b/build.sh
@@ -11,11 +11,17 @@ ln -s ${XERCES_DIR}/build/lib/libxerces-c-3.2.a ${XERCES_DIR}/build/lib/libxerce
 
 
 cd ${THIS_DIR}
-./configure \
+CONFIGURE_OPTIONS= \
         --with-libraries=/usr/lib/x86_64-linux-gnu \
         --with-xerces-headers=${XERCES_DIR}/build/include \
         --with-xerces-libraries=${XERCES_DIR}/build/lib \
-        --options=-static \
         --with-xml
+
+# OS が Linux であれば、スタティックリンクを行う
+if [ "$(expr substr $(uname -s) 1 5)" == 'Linux' ]; then
+    CONFIGURE_OPTIONS=--options=-static ${CONFIGURE_OPTIONS}
+fi
+
+./configure ${CONFIGURE_OPTIONS}
 make
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+THIS_DIR=$(cd $(dirname $0); pwd)
+XERCES_DIR=${THIS_DIR}/depend_libs/xerces-c
+
+cd ${XERCES_DIR}
+cmake -G "Unix Makefiles" -DCMAKE_INSTALL_PREFIX=${XERCES_DIR}/build -Dnetwork:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=OFF
+make
+make install
+ln -s ${XERCES_DIR}/build/lib/libxerces-c-3.2.a ${XERCES_DIR}/build/lib/libxerces-c.a
+
+
+cd ${THIS_DIR}
+./configure \
+        --with-libraries=/usr/lib/x86_64-linux-gnu \
+        --with-xerces-headers=${XERCES_DIR}/build/include \
+        --with-xerces-libraries=${XERCES_DIR}/build/lib \
+        --with-xml
+make
+

--- a/build.sh
+++ b/build.sh
@@ -15,6 +15,7 @@ cd ${THIS_DIR}
         --with-libraries=/usr/lib/x86_64-linux-gnu \
         --with-xerces-headers=${XERCES_DIR}/build/include \
         --with-xerces-libraries=${XERCES_DIR}/build/lib \
+        --options=-static \
         --with-xml
 make
 

--- a/cfg/Makefile
+++ b/cfg/Makefile
@@ -48,7 +48,7 @@ LIBFILES := $(LIBFILES) $(PROJDIR)/toppers/libtoppers.a \
 all: cfg
 
 cfg: $(OBJFILES) $(LIBFILES)
-	$(CXX) $(LDFLAGS) -o cfg $(OBJFILES) -L$(LIBBOOST_DIR) -L$(LIBXERCES_DIR) $(LIBFILES) $(BOOST_LIBFILES) $(XERCES_LIBSFILE) -lpthread
+	$(CXX) $(LDFLAGS) -o cfg $(OBJFILES) -L$(LIBBOOST_DIR) -L$(LIBXERCES_DIR) $(LIBFILES) $(BOOST_LIBFILES) $(XERCES_LIBSFILE) -lpthread -ldl
 
 depend:
 	$(CXX) $(CPPFLAGS) -M $(CXXFILES) > Makefile.depend

--- a/configure
+++ b/configure
@@ -10,9 +10,12 @@ do
 	value=`echo $arg | cut -d "=" -f 2`
 
 	case $name in
-		--with-headers)		include_path=$value ;;
-		--with-libraries)	library_path=$value ;;
-		--with-xml)			with_xml=1 ;;
+		--with-headers)				include_path=$value ;;
+		--with-libraries)			library_path=$value ;;
+		--with-xerces-headers)		xerces_include_path=$value ;;
+ 		--with-xerces-libraries)	xerces_library_path=$value ;;
+		--options)					options=$value ;;
+		--with-xml)					with_xml=1 ;;
 		--help)				echo "configure options:"
 							echo "--help"
 							echo "	display this information"
@@ -76,12 +79,21 @@ fi
 libboost_suffix=`echo $libboost_regex_filename | sed -e s/.*libboost_regex//g -e s/\.[a-z]*$//g`
 echo "LIBBOOST_SUFFIX=$libboost_suffix" >> $makefile_config
 
+if [ ! "$xerces_include_path" ]; then
+    xerces_include_path=$include_path
+fi
+
+if [ ! "$xerces_library_path" ]; then
+    xerces_library_path=$library_path
+fi
+
+
 # 各種変数を出力
 echo BOOST_VERSION=$boost_lib_version >> $makefile_config
 echo BOOST_DIR=$include_path >> $makefile_config
-echo XERCES_DIR=$include_path >> $makefile_config
+echo XERCES_DIR=$xerces_include_path >> $makefile_config
 echo LIBBOOST_DIR=$library_path >> $makefile_config
-echo LIBXERCES_DIR=$library_path >> $makefile_config
+echo LIBXERCES_DIR=$xerces_library_path >> $makefile_config
 echo OPTIONS=$options >> $makefile_config
 if test $with_xml -eq 1
 then


### PR DESCRIPTION
[TOPPERS cfg の 64 bit ビルドに挑戦した記録(その４ 最適化なしのスタティックリンクバイナリを作った) ](https://mikoto2000.blogspot.com/2019/01/toppers-cfg-64-bit_26.html)の手順を Travis 上で実行するように修正しました。

- xerces のミラーを submodule として追加
- 最適化を無効化
- ubuntu xenial でスタティックビルドできるように、リンクオプションに `-ldl` を追加    
- Makefile.config を sed コマンドで書き換えるのはスマートでないため、configure のオプションとして xerces のパスを指定できるように修正
- ubuntu xenial でのスタティックビルド手順を定義した build.sh を追加