### PR TITLE
最適化を無効にしたスタティックリンクバイナリをビルドするように修正

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: cpp
 
+env:
+  global:
+    CPPFLAGS='-std=c++11'
 matrix:
     include:
         - os: osx
@@ -16,14 +19,14 @@ addons:
     - perl
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libboost-all-dev; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libxerces-c-dev; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y wget bzip2; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew update          ; fi
 #    - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install boost; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install xerces-c; fi
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]];   then brew install icu4c; fi
 
 script: 
-    ./configure --with-xml && make
+    ./build.sh
 after_success:
     - cd cfg ; tar cvzf "cfg-${TRAVIS_BRANCH}-${TARGET}.tar.gz" cfg ; cd ../
     - mkdir -p $TRAVIS_BUILD_DIR/dist ; cp cfg/"cfg-${TRAVIS_BRANCH}-${TARGET}.tar.gz" $TRAVIS_BUILD_DIR/dist/ ; cd $TRAVIS_BUILD_DIR/dist

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ endif
 
 # 非力なマシンなどでコンパイルに非常に長い時間がかかる、もしくはコンパイル時に
 # ハングアップする場合には、-O0に変更してみてください。
-OPTIMIZE = -O2
+OPTIMIZE = -O0
 
 MODULES = toppers/itronx \
 	toppers/oil

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+#
+# build.sh
+#
+# スタティックリンクの実行ファイルビルド用スクリプト
+#
+# 動作条件
+#     Ubuntu 18.04 での実行を想定しています。
+#     Ubuntu 16.04 で実行する場合には、環境変数 CPPFLAGS="-std=c++11" を指定してください。
+#
+# 事前に導入が必要な必要パッケージ
+#     - make
+#     - wget
+#     - tar
+#     - bzip2
+#     - g++
+#     - libboost-dev
+#     - libboost-regex-dev
+#     - libboost-system-dev
+#     - libboost-filesystem-dev
+#     - libboost-program-options-dev     - 
+
+THIS_DIR=$(cd $(dirname $0); pwd)
+DEPEND_LIBS_DIR=${THIS_DIR}/depend_libs
+XERCES_DIR=${DEPEND_LIBS_DIR}/xerces-c-3.2.2
+XERCES_URL=http://archive.apache.org/dist/xerces/c/3/sources
+XERCES_TB_NAME=xerces-c-3.2.2.tar.bz2
+LIBS_INSTALL_PATH=${DEPEND_LIBS_DIR}/opt/local
+
+# 依存ライブラリ展開用ディレクトリ作成
+mkdir -p ${DEPEND_LIBS_DIR}
+
+# xerces の準備
+if [ ! -e ${DEPEND_LIBS_DIR}/${XERCES_TB_NAME} ]; then
+    wget ${XERCES_URL}/${XERCES_TB_NAME} -O ${DEPEND_LIBS_DIR}/${XERCES_TB_NAME}
+fi
+
+cd ${DEPEND_LIBS_DIR}
+if [ ! -e ${XERCES_DIR} ]; then
+    # xerces を展開
+    tar xfv ${XERCES_TB_NAME}
+fi
+
+cd ${XERCES_DIR}
+./configure --prefix=${LIBS_INSTALL_PATH} --disable-network --disable-shared
+make
+make install
+
+cd ${THIS_DIR}
+CONFIGURE_OPTIONS="--with-xml --with-xerces-headers=${LIBS_INSTALL_PATH}/include --with-xerces-libraries=${LIBS_INSTALL_PATH}/lib"
+
+# OS が Linux であれば、スタティックリンクを行う
+if [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+    CONFIGURE_OPTIONS+=" --options=-static"
+fi
+
+./configure ${CONFIGURE_OPTIONS}
+make
+

--- a/cfg/Makefile
+++ b/cfg/Makefile
@@ -48,7 +48,7 @@ LIBFILES := $(LIBFILES) $(PROJDIR)/toppers/libtoppers.a \
 all: cfg
 
 cfg: $(OBJFILES) $(LIBFILES)
-	$(CXX) $(LDFLAGS) -o cfg $(OBJFILES) -L$(LIBBOOST_DIR) -L$(LIBXERCES_DIR) $(LIBFILES) $(BOOST_LIBFILES) $(XERCES_LIBSFILE) -lpthread
+	$(CXX) $(LDFLAGS) -o cfg $(OBJFILES) -L$(LIBBOOST_DIR) -L$(LIBXERCES_DIR) $(LIBFILES) $(BOOST_LIBFILES) $(XERCES_LIBSFILE) -lpthread -ldl
 
 depend:
 	$(CXX) $(CPPFLAGS) -M $(CXXFILES) > Makefile.depend

--- a/configure
+++ b/configure
@@ -10,9 +10,12 @@ do
 	value=`echo $arg | cut -d "=" -f 2`
 
 	case $name in
-		--with-headers)		include_path=$value ;;
-		--with-libraries)	library_path=$value ;;
-		--with-xml)			with_xml=1 ;;
+		--with-headers)				include_path=$value ;;
+		--with-libraries)			library_path=$value ;;
+		--with-xerces-headers)		xerces_include_path=$value ;;
+ 		--with-xerces-libraries)	xerces_library_path=$value ;;
+		--options)					options=$value ;;
+		--with-xml)					with_xml=1 ;;
 		--help)				echo "configure options:"
 							echo "--help"
 							echo "	display this information"
@@ -76,12 +79,21 @@ fi
 libboost_suffix=`echo $libboost_regex_filename | sed -e s/.*libboost_regex//g -e s/\.[a-z]*$//g`
 echo "LIBBOOST_SUFFIX=$libboost_suffix" >> $makefile_config
 
+if [ ! "$xerces_include_path" ]; then
+    xerces_include_path=$include_path
+fi
+
+if [ ! "$xerces_library_path" ]; then
+    xerces_library_path=$library_path
+fi
+
+
 # 各種変数を出力
 echo BOOST_VERSION=$boost_lib_version >> $makefile_config
 echo BOOST_DIR=$include_path >> $makefile_config
-echo XERCES_DIR=$include_path >> $makefile_config
+echo XERCES_DIR=$xerces_include_path >> $makefile_config
 echo LIBBOOST_DIR=$library_path >> $makefile_config
-echo LIBXERCES_DIR=$library_path >> $makefile_config
+echo LIBXERCES_DIR=$xerces_library_path >> $makefile_config
 echo OPTIONS=$options >> $makefile_config
 if test $with_xml -eq 1
 then


### PR DESCRIPTION
[TOPPERS cfg の 64 bit ビルドに挑戦した記録(その４ 最適化なしのスタティックリンクバイナリを作った) ](https://mikoto2000.blogspot.com/2019/01/toppers-cfg-64-bit_26.html)の手順を Travis 上で実行するように修正しました。

- 最適化を無効化
- ubuntu xenial でスタティックビルドできるように、リンクオプションに `-ldl` を追加    
- Makefile.config を sed コマンドで書き換えるのはスマートでないため、configure のオプションとして xerces のパスを指定できるように修正
- ubuntu xenial でのスタティックビルド手順を定義した build.sh を追加
- travis のビルドファイル修正