### PR TITLE
shared_ptr の排他制御を有効化。

### DIFF
--- a/toppers/workaround.hpp
+++ b/toppers/workaround.hpp
@@ -63,7 +63,6 @@
 
 #else
 
-#define BOOST_SP_DISABLE_THREADS  1   // shared_ptr の排他制御を抑止
 #include <boost/shared_ptr.hpp>
 #include <boost/weak_ptr.hpp>
 #include <boost/cstdint.hpp>


### PR DESCRIPTION
#9 の修正です。

以下の通り計測を行い、 `shared_ptr` の排他を無効にするよりも、コンパイラの最適化を有効にしたほうが効果が高いという結論になりました。

そのため、 `O2` を指定したまま Segmentation fault を回避できるように、 `BOOST_SP_DISABLE_THREADS` を削除しました。


## サイズ比較

```
root@9a5b61e381ad:/athrill/sample/os/atk2-sc1_1.4.2/cfg/cfg# ls -l cfg_tr1_*
-rwxr-xr-x 1 root root 10120648 Jun 12 17:25 cfg_tr1_o0
-rwxr-xr-x 1 root root  2994968 Jun 12 17:33 cfg_tr1_o2
```

- `cfg_tr1_o0`: BOOST_SP_DISABLE_THREADS を残して O0 ビルド
- `cfg_tr1_o2`: BOOST_SP_DISABLE_THREADS 削除して O2 ビルド


## 実行時間

確認コマンドは以下の通り。([tmori/athrill 付属の ATK2 サンプルにて動作確認](https://github.com/tmori/athrill/tree/013113c347d177d0ac9d2b7d5c8685da204016b4/sample/os/atk2-sc1_1.4.2/OBJ))

```
root@9a5b61e381ad:/athrill/sample/os/atk2-sc1_1.4.2/OBJ# time ../cfg/cfg/cfg  --pass 2 --kernel atk2 -I. -I../include -I../arch -I.. -I../target/v850esfk3_gcc -I..//arch/v850esfk3_gcc -I..//arch/gcc -T ../target/v850esfk3_gcc/target.tf --api-table ../kernel/kernel.csv --cfg1-def-table ../kernel/kernel_def.csv --ini-file ../kernel/kernel.ini  --cfg1-def-table ..//arch/v850esfk3_gcc/prc_def.csv sample1.arxml ..//arch/v850esfk3_gcc/uart.arxml ../target/v850esfk3_gcc/target_hw_counter.arxml
```

### 比較結果

BOOST_SP_DISABLE_THREADS を残して O0 ビルド

```
real    0m3.775s
user    0m3.660s
sys     0m0.010s
```

BOOST_SP_DISABLE_THREADS 削除して O2 ビルド

```
real    0m1.024s
user    0m0.880s
sys     0m0.040s
```

